### PR TITLE
Could not print in landscape mode due to swapped PdfOrientation enums

### DIFF
--- a/WkHtmlToXSharp/PdfGlobalSettings.cs
+++ b/WkHtmlToXSharp/PdfGlobalSettings.cs
@@ -32,8 +32,8 @@ using System.Text;
 namespace WkHtmlToXSharp
 {
 	public enum PdfOrientation {
-		Landscape,
-		Portrait
+		Portrait,
+		Landscape
 	}
 
 	public class PdfGlobalSettings


### PR DESCRIPTION
Swapped them to the correct values, so now it is working.
