### PR TITLE
Username and Password properties with wrong type and name

### DIFF
--- a/WkHtmlToXSharp/LoadSettings.cs
+++ b/WkHtmlToXSharp/LoadSettings.cs
@@ -33,8 +33,8 @@ namespace WkHtmlToXSharp
 {
 	public class LoadSettings
 	{
-		public bool UserName { get; set; }
-		public bool Password { get; set; }
+		public string Username { get; set; }
+		public string Password { get; set; }
 	    public string Proxy { get; set; }
 
         private string _windowStatus = "";


### PR DESCRIPTION
Changed username and password properties so they could be read from load settings.
This will in theory enable converting pages with authentication required.
