### PR TITLE
Map PdfGlobalSettings.ImageDPI to valid wkhtml global setting key

### DIFF
--- a/WkHtmlToXSharp/PdfGlobalSettings.cs
+++ b/WkHtmlToXSharp/PdfGlobalSettings.cs
@@ -71,7 +71,7 @@ namespace WkHtmlToXSharp
 		};
 
 		public int Dpi { get; set; }
-		public int ImageDpi { get; set; }
+		public int ImageDPI { get; set; }
 		public int ImageQuality { get; set; }
 		public PdfMarginSettings Margin { get { return _margins; } }
 


### PR DESCRIPTION
https://wkhtmltopdf.org/libwkhtmltox/pagesettings.html

Setting ImageDPI after the rename fixes this.
<img width="1282" height="217" alt="image" src="https://github.com/user-attachments/assets/f08889a2-0b92-4c16-9368-6101c5ba92aa" />

